### PR TITLE
Fix for issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository serves as an **example** on how to use [Codecov Global][4] for J
 <plugin>
   <groupId>org.jacoco</groupId>
   <artifactId>jacoco-maven-plugin</artifactId>
-  <version>0.5.8.201207111220</version>
+  <version>0.7.5.201505241946</version>
   <executions>
     <execution>
       <goals>


### PR DESCRIPTION
Updated the Jacoco plugin to the latest as it seems to work with Java 8.
Seems to me that Jacoco fixed support for Java 8 starting with v0.7..
https://github.com/jacoco/jacoco/issues/74
But I didn't bother to use an older version and therefore took the latest

Verified this with my own project:
https://github.com/pnerg/java-scala-util
https://codecov.io/github/pnerg/java-scala-util?branch=master
