### PR TITLE
Add missing link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Please see [http://stackoverflow.com/questions/18107375/...](http://stackoverflo
 [2]: https://github.com/codecov/example-gradle
 [3]: https://github.com/codecov/example-android
 [4]: https://github.com/codecov/example-java-maven
+[5]: https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token


### PR DESCRIPTION
In the markdown file, there was a link missing to the documentation of the repository token. This has been fixed by adding the same link that it used [at the example java project](https://github.com/codecov/example-java-maven)