### PR TITLE
Build dependencies fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -38,7 +38,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.2</version>
+				<version>0.8.5</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin> 
+				<groupId>org.apache.maven.plugins</groupId> 
+				<artifactId>maven-compiler-plugin</artifactId> 
+				<version>3.8.0</version> 
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The maven plugin version defaults to Java 5, which ultimately, fails the build in a CI Service.
Solution:
- Configure maven plugin version to 3.8.0 which uses the later versions of Java (which is compatible with this repo)

Message to visitors: If this Pull Request does not get merged, use my Pull Request as a reference.